### PR TITLE
商品詳細画面（soldout時）

### DIFF
--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -31,9 +31,13 @@
       <%# 購入機能追加で確認するため、コメントアウトは残しておきます %>
     <% if user_signed_in?%>
       <%if current_user.id == @item.user_id %>
-      <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
-      <p class='or-text'>or</p>
-      <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
+        <%if @item.purchase == nil %>
+          <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
+          <p class='or-text'>or</p>
+          <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
+        <% else %>
+          <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
+        <% end %>
 
       <%# 商品が売れていない場合はこちらを表示しましょう %>
       <% else %>


### PR DESCRIPTION
#What
商品詳細画面の編集。
売り切れた商品は出品者も削除できないようにした。

#Why
soldout時の商品詳細画面や削除機能については言及されてなかったため、
エラー文が出ないように削除ボタンを出さない条件分岐を設定した。